### PR TITLE
Implement Epic 1 & 2: Move entity, SF6 fields, and full CRUD API

### DIFF
--- a/src/main/java/com/fgc/framedata_api/controller/MoveController.java
+++ b/src/main/java/com/fgc/framedata_api/controller/MoveController.java
@@ -1,0 +1,75 @@
+package com.fgc.framedata_api.controller;
+
+import com.fgc.framedata_api.dto.MoveDTO;
+import com.fgc.framedata_api.request.CreateMoveRequest;
+import com.fgc.framedata_api.request.UpdateMoveRequest;
+import com.fgc.framedata_api.response.ListMoveResponse;
+import com.fgc.framedata_api.service.MoveService;
+import com.fgc.framedata_api.utils.CustomExceptions;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/characters/{characterId}/moves")
+public class MoveController {
+
+    private final MoveService moveService;
+
+    public MoveController(MoveService moveService) {
+        this.moveService = moveService;
+    }
+
+    @GetMapping
+    public ResponseEntity<ListMoveResponse> getAllMovesByCharacter(@PathVariable Long characterId) {
+        try {
+            List<MoveDTO> moves = moveService.getAllMovesByCharacter(characterId);
+            return ResponseEntity.ok(new ListMoveResponse(moves));
+        } catch (CustomExceptions.CharacterNotFoundException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<MoveDTO> addMove(@PathVariable Long characterId, @RequestBody CreateMoveRequest request) {
+        try {
+            MoveDTO createdMove = moveService.addMove(characterId, request);
+            return ResponseEntity.status(201).body(createdMove);
+        } catch (CustomExceptions.CharacterNotFoundException | CustomExceptions.MoveNotFoundException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
+        }
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<MoveDTO> getMoveById(@PathVariable Long characterId, @PathVariable Long id) {
+        try {
+            MoveDTO move = moveService.getMoveById(id);
+            return ResponseEntity.ok(move);
+        } catch (CustomExceptions.MoveNotFoundException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
+        }
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<MoveDTO> updateMove(@PathVariable Long characterId, @PathVariable Long id, @RequestBody UpdateMoveRequest request) {
+        try {
+            MoveDTO updatedMove = moveService.updateMove(id, request);
+            return ResponseEntity.ok(updatedMove);
+        } catch (CustomExceptions.MoveNotFoundException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteMove(@PathVariable Long characterId, @PathVariable Long id) {
+        try {
+            moveService.deleteMove(id);
+            return ResponseEntity.noContent().build();
+        } catch (CustomExceptions.MoveNotFoundException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/fgc/framedata_api/dto/CharacterDTO.java
+++ b/src/main/java/com/fgc/framedata_api/dto/CharacterDTO.java
@@ -7,6 +7,7 @@ public class CharacterDTO {
     private Long id;
     private String name;
     private String gameName;
+    private String patchVersion;
 
     public CharacterDTO() {
     }
@@ -38,5 +39,13 @@ public class CharacterDTO {
 
     public void setGameName(String gameName) {
         this.gameName = gameName;
+    }
+
+    public String getPatchVersion() {
+        return patchVersion;
+    }
+
+    public void setPatchVersion(String patchVersion) {
+        this.patchVersion = patchVersion;
     }
 }

--- a/src/main/java/com/fgc/framedata_api/dto/MoveDTO.java
+++ b/src/main/java/com/fgc/framedata_api/dto/MoveDTO.java
@@ -1,0 +1,99 @@
+package com.fgc.framedata_api.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fgc.framedata_api.model.MoveType;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MoveDTO {
+
+    private Long id;
+    private Long characterId;
+    private Long parentMoveId;
+    private String name;
+    private String input;
+    private MoveType moveType;
+    private Integer superArtLevel;
+    private Integer damage;
+    private Integer chipDamage;
+    private Integer startupFrames;
+    private Integer activeFrames;
+    private Integer recoveryFrames;
+    private Integer onHitAdvantage;
+    private Integer onBlockAdvantage;
+    private Integer onCounterHitAdvantage;
+    private Integer onPunishCounterAdvantage;
+    private Integer driveRushOnHit;
+    private Integer driveRushOnBlock;
+    private Boolean hasArmor;
+    private Integer armorHits;
+    private String cancelOptions;
+    private String notes;
+
+    public MoveDTO() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Long getCharacterId() { return characterId; }
+    public void setCharacterId(Long characterId) { this.characterId = characterId; }
+
+    public Long getParentMoveId() { return parentMoveId; }
+    public void setParentMoveId(Long parentMoveId) { this.parentMoveId = parentMoveId; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getInput() { return input; }
+    public void setInput(String input) { this.input = input; }
+
+    public MoveType getMoveType() { return moveType; }
+    public void setMoveType(MoveType moveType) { this.moveType = moveType; }
+
+    public Integer getSuperArtLevel() { return superArtLevel; }
+    public void setSuperArtLevel(Integer superArtLevel) { this.superArtLevel = superArtLevel; }
+
+    public Integer getDamage() { return damage; }
+    public void setDamage(Integer damage) { this.damage = damage; }
+
+    public Integer getChipDamage() { return chipDamage; }
+    public void setChipDamage(Integer chipDamage) { this.chipDamage = chipDamage; }
+
+    public Integer getStartupFrames() { return startupFrames; }
+    public void setStartupFrames(Integer startupFrames) { this.startupFrames = startupFrames; }
+
+    public Integer getActiveFrames() { return activeFrames; }
+    public void setActiveFrames(Integer activeFrames) { this.activeFrames = activeFrames; }
+
+    public Integer getRecoveryFrames() { return recoveryFrames; }
+    public void setRecoveryFrames(Integer recoveryFrames) { this.recoveryFrames = recoveryFrames; }
+
+    public Integer getOnHitAdvantage() { return onHitAdvantage; }
+    public void setOnHitAdvantage(Integer onHitAdvantage) { this.onHitAdvantage = onHitAdvantage; }
+
+    public Integer getOnBlockAdvantage() { return onBlockAdvantage; }
+    public void setOnBlockAdvantage(Integer onBlockAdvantage) { this.onBlockAdvantage = onBlockAdvantage; }
+
+    public Integer getOnCounterHitAdvantage() { return onCounterHitAdvantage; }
+    public void setOnCounterHitAdvantage(Integer onCounterHitAdvantage) { this.onCounterHitAdvantage = onCounterHitAdvantage; }
+
+    public Integer getOnPunishCounterAdvantage() { return onPunishCounterAdvantage; }
+    public void setOnPunishCounterAdvantage(Integer onPunishCounterAdvantage) { this.onPunishCounterAdvantage = onPunishCounterAdvantage; }
+
+    public Integer getDriveRushOnHit() { return driveRushOnHit; }
+    public void setDriveRushOnHit(Integer driveRushOnHit) { this.driveRushOnHit = driveRushOnHit; }
+
+    public Integer getDriveRushOnBlock() { return driveRushOnBlock; }
+    public void setDriveRushOnBlock(Integer driveRushOnBlock) { this.driveRushOnBlock = driveRushOnBlock; }
+
+    public Boolean getHasArmor() { return hasArmor; }
+    public void setHasArmor(Boolean hasArmor) { this.hasArmor = hasArmor; }
+
+    public Integer getArmorHits() { return armorHits; }
+    public void setArmorHits(Integer armorHits) { this.armorHits = armorHits; }
+
+    public String getCancelOptions() { return cancelOptions; }
+    public void setCancelOptions(String cancelOptions) { this.cancelOptions = cancelOptions; }
+
+    public String getNotes() { return notes; }
+    public void setNotes(String notes) { this.notes = notes; }
+}

--- a/src/main/java/com/fgc/framedata_api/model/Character.java
+++ b/src/main/java/com/fgc/framedata_api/model/Character.java
@@ -16,6 +16,8 @@ public class Character {
     @JoinColumn(name = "game_id", nullable = false)
     private Game game;
 
+    private String patchVersion;
+
     public Long getId() {
         return id;
     }
@@ -38,5 +40,13 @@ public class Character {
 
     public void setGame(Game game) {
         this.game = game;
+    }
+
+    public String getPatchVersion() {
+        return patchVersion;
+    }
+
+    public void setPatchVersion(String patchVersion) {
+        this.patchVersion = patchVersion;
     }
 }

--- a/src/main/java/com/fgc/framedata_api/model/Move.java
+++ b/src/main/java/com/fgc/framedata_api/model/Move.java
@@ -1,0 +1,116 @@
+package com.fgc.framedata_api.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "moves")
+public class Move {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "character_id", nullable = false)
+    private Character character;
+
+    @ManyToOne
+    @JoinColumn(name = "parent_move_id")
+    private Move parentMove;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String input;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MoveType moveType;
+
+    private Integer superArtLevel;
+    private Integer damage;
+    private Integer chipDamage;
+    private Integer startupFrames;
+    private Integer activeFrames;
+    private Integer recoveryFrames;
+    private Integer onHitAdvantage;
+    private Integer onBlockAdvantage;
+    private Integer onCounterHitAdvantage;
+    private Integer onPunishCounterAdvantage;
+    private Integer driveRushOnHit;
+    private Integer driveRushOnBlock;
+
+    @Column(nullable = false)
+    private Boolean hasArmor = false;
+
+    private Integer armorHits;
+    private String cancelOptions;
+    private String notes;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Character getCharacter() { return character; }
+    public void setCharacter(Character character) { this.character = character; }
+
+    public Move getParentMove() { return parentMove; }
+    public void setParentMove(Move parentMove) { this.parentMove = parentMove; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getInput() { return input; }
+    public void setInput(String input) { this.input = input; }
+
+    public MoveType getMoveType() { return moveType; }
+    public void setMoveType(MoveType moveType) { this.moveType = moveType; }
+
+    public Integer getSuperArtLevel() { return superArtLevel; }
+    public void setSuperArtLevel(Integer superArtLevel) { this.superArtLevel = superArtLevel; }
+
+    public Integer getDamage() { return damage; }
+    public void setDamage(Integer damage) { this.damage = damage; }
+
+    public Integer getChipDamage() { return chipDamage; }
+    public void setChipDamage(Integer chipDamage) { this.chipDamage = chipDamage; }
+
+    public Integer getStartupFrames() { return startupFrames; }
+    public void setStartupFrames(Integer startupFrames) { this.startupFrames = startupFrames; }
+
+    public Integer getActiveFrames() { return activeFrames; }
+    public void setActiveFrames(Integer activeFrames) { this.activeFrames = activeFrames; }
+
+    public Integer getRecoveryFrames() { return recoveryFrames; }
+    public void setRecoveryFrames(Integer recoveryFrames) { this.recoveryFrames = recoveryFrames; }
+
+    public Integer getOnHitAdvantage() { return onHitAdvantage; }
+    public void setOnHitAdvantage(Integer onHitAdvantage) { this.onHitAdvantage = onHitAdvantage; }
+
+    public Integer getOnBlockAdvantage() { return onBlockAdvantage; }
+    public void setOnBlockAdvantage(Integer onBlockAdvantage) { this.onBlockAdvantage = onBlockAdvantage; }
+
+    public Integer getOnCounterHitAdvantage() { return onCounterHitAdvantage; }
+    public void setOnCounterHitAdvantage(Integer onCounterHitAdvantage) { this.onCounterHitAdvantage = onCounterHitAdvantage; }
+
+    public Integer getOnPunishCounterAdvantage() { return onPunishCounterAdvantage; }
+    public void setOnPunishCounterAdvantage(Integer onPunishCounterAdvantage) { this.onPunishCounterAdvantage = onPunishCounterAdvantage; }
+
+    public Integer getDriveRushOnHit() { return driveRushOnHit; }
+    public void setDriveRushOnHit(Integer driveRushOnHit) { this.driveRushOnHit = driveRushOnHit; }
+
+    public Integer getDriveRushOnBlock() { return driveRushOnBlock; }
+    public void setDriveRushOnBlock(Integer driveRushOnBlock) { this.driveRushOnBlock = driveRushOnBlock; }
+
+    public Boolean getHasArmor() { return hasArmor; }
+    public void setHasArmor(Boolean hasArmor) { this.hasArmor = hasArmor; }
+
+    public Integer getArmorHits() { return armorHits; }
+    public void setArmorHits(Integer armorHits) { this.armorHits = armorHits; }
+
+    public String getCancelOptions() { return cancelOptions; }
+    public void setCancelOptions(String cancelOptions) { this.cancelOptions = cancelOptions; }
+
+    public String getNotes() { return notes; }
+    public void setNotes(String notes) { this.notes = notes; }
+}

--- a/src/main/java/com/fgc/framedata_api/model/MoveType.java
+++ b/src/main/java/com/fgc/framedata_api/model/MoveType.java
@@ -1,0 +1,11 @@
+package com.fgc.framedata_api.model;
+
+public enum MoveType {
+    NORMAL,
+    SPECIAL,
+    OD_SPECIAL,
+    SUPER_ART,
+    THROW,
+    STANCE,
+    TARGET_COMBO
+}

--- a/src/main/java/com/fgc/framedata_api/repository/MoveRepository.java
+++ b/src/main/java/com/fgc/framedata_api/repository/MoveRepository.java
@@ -1,0 +1,11 @@
+package com.fgc.framedata_api.repository;
+
+import com.fgc.framedata_api.model.Move;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MoveRepository extends JpaRepository<Move, Long> {
+    List<Move> findAllByCharacterId(Long characterId);
+    List<Move> findAllByParentMoveId(Long parentMoveId);
+}

--- a/src/main/java/com/fgc/framedata_api/request/CreateCharacterRequest.java
+++ b/src/main/java/com/fgc/framedata_api/request/CreateCharacterRequest.java
@@ -3,6 +3,7 @@ package com.fgc.framedata_api.request;
 public class CreateCharacterRequest {
     private String name;
     private Long gameId;
+    private String patchVersion;
 
     public void setName(String name) {
         this.name = name;
@@ -18,5 +19,13 @@ public class CreateCharacterRequest {
 
     public Long getGameId() {
         return gameId;
+    }
+
+    public String getPatchVersion() {
+        return patchVersion;
+    }
+
+    public void setPatchVersion(String patchVersion) {
+        this.patchVersion = patchVersion;
     }
 }

--- a/src/main/java/com/fgc/framedata_api/request/CreateMoveRequest.java
+++ b/src/main/java/com/fgc/framedata_api/request/CreateMoveRequest.java
@@ -1,0 +1,87 @@
+package com.fgc.framedata_api.request;
+
+import com.fgc.framedata_api.model.MoveType;
+
+public class CreateMoveRequest {
+
+    private Long parentMoveId;
+    private String name;
+    private String input;
+    private MoveType moveType;
+    private Integer superArtLevel;
+    private Integer damage;
+    private Integer chipDamage;
+    private Integer startupFrames;
+    private Integer activeFrames;
+    private Integer recoveryFrames;
+    private Integer onHitAdvantage;
+    private Integer onBlockAdvantage;
+    private Integer onCounterHitAdvantage;
+    private Integer onPunishCounterAdvantage;
+    private Integer driveRushOnHit;
+    private Integer driveRushOnBlock;
+    private Boolean hasArmor = false;
+    private Integer armorHits;
+    private String cancelOptions;
+    private String notes;
+
+    public Long getParentMoveId() { return parentMoveId; }
+    public void setParentMoveId(Long parentMoveId) { this.parentMoveId = parentMoveId; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getInput() { return input; }
+    public void setInput(String input) { this.input = input; }
+
+    public MoveType getMoveType() { return moveType; }
+    public void setMoveType(MoveType moveType) { this.moveType = moveType; }
+
+    public Integer getSuperArtLevel() { return superArtLevel; }
+    public void setSuperArtLevel(Integer superArtLevel) { this.superArtLevel = superArtLevel; }
+
+    public Integer getDamage() { return damage; }
+    public void setDamage(Integer damage) { this.damage = damage; }
+
+    public Integer getChipDamage() { return chipDamage; }
+    public void setChipDamage(Integer chipDamage) { this.chipDamage = chipDamage; }
+
+    public Integer getStartupFrames() { return startupFrames; }
+    public void setStartupFrames(Integer startupFrames) { this.startupFrames = startupFrames; }
+
+    public Integer getActiveFrames() { return activeFrames; }
+    public void setActiveFrames(Integer activeFrames) { this.activeFrames = activeFrames; }
+
+    public Integer getRecoveryFrames() { return recoveryFrames; }
+    public void setRecoveryFrames(Integer recoveryFrames) { this.recoveryFrames = recoveryFrames; }
+
+    public Integer getOnHitAdvantage() { return onHitAdvantage; }
+    public void setOnHitAdvantage(Integer onHitAdvantage) { this.onHitAdvantage = onHitAdvantage; }
+
+    public Integer getOnBlockAdvantage() { return onBlockAdvantage; }
+    public void setOnBlockAdvantage(Integer onBlockAdvantage) { this.onBlockAdvantage = onBlockAdvantage; }
+
+    public Integer getOnCounterHitAdvantage() { return onCounterHitAdvantage; }
+    public void setOnCounterHitAdvantage(Integer onCounterHitAdvantage) { this.onCounterHitAdvantage = onCounterHitAdvantage; }
+
+    public Integer getOnPunishCounterAdvantage() { return onPunishCounterAdvantage; }
+    public void setOnPunishCounterAdvantage(Integer onPunishCounterAdvantage) { this.onPunishCounterAdvantage = onPunishCounterAdvantage; }
+
+    public Integer getDriveRushOnHit() { return driveRushOnHit; }
+    public void setDriveRushOnHit(Integer driveRushOnHit) { this.driveRushOnHit = driveRushOnHit; }
+
+    public Integer getDriveRushOnBlock() { return driveRushOnBlock; }
+    public void setDriveRushOnBlock(Integer driveRushOnBlock) { this.driveRushOnBlock = driveRushOnBlock; }
+
+    public Boolean getHasArmor() { return hasArmor; }
+    public void setHasArmor(Boolean hasArmor) { this.hasArmor = hasArmor; }
+
+    public Integer getArmorHits() { return armorHits; }
+    public void setArmorHits(Integer armorHits) { this.armorHits = armorHits; }
+
+    public String getCancelOptions() { return cancelOptions; }
+    public void setCancelOptions(String cancelOptions) { this.cancelOptions = cancelOptions; }
+
+    public String getNotes() { return notes; }
+    public void setNotes(String notes) { this.notes = notes; }
+}

--- a/src/main/java/com/fgc/framedata_api/request/UpdateCharacterRequest.java
+++ b/src/main/java/com/fgc/framedata_api/request/UpdateCharacterRequest.java
@@ -2,6 +2,7 @@ package com.fgc.framedata_api.request;
 
 public class UpdateCharacterRequest {
     private String name;
+    private String patchVersion;
 
     public UpdateCharacterRequest() {
     }
@@ -16,5 +17,13 @@ public class UpdateCharacterRequest {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getPatchVersion() {
+        return patchVersion;
+    }
+
+    public void setPatchVersion(String patchVersion) {
+        this.patchVersion = patchVersion;
     }
 }

--- a/src/main/java/com/fgc/framedata_api/request/UpdateMoveRequest.java
+++ b/src/main/java/com/fgc/framedata_api/request/UpdateMoveRequest.java
@@ -1,0 +1,87 @@
+package com.fgc.framedata_api.request;
+
+import com.fgc.framedata_api.model.MoveType;
+
+public class UpdateMoveRequest {
+
+    private Long parentMoveId;
+    private String name;
+    private String input;
+    private MoveType moveType;
+    private Integer superArtLevel;
+    private Integer damage;
+    private Integer chipDamage;
+    private Integer startupFrames;
+    private Integer activeFrames;
+    private Integer recoveryFrames;
+    private Integer onHitAdvantage;
+    private Integer onBlockAdvantage;
+    private Integer onCounterHitAdvantage;
+    private Integer onPunishCounterAdvantage;
+    private Integer driveRushOnHit;
+    private Integer driveRushOnBlock;
+    private Boolean hasArmor;
+    private Integer armorHits;
+    private String cancelOptions;
+    private String notes;
+
+    public Long getParentMoveId() { return parentMoveId; }
+    public void setParentMoveId(Long parentMoveId) { this.parentMoveId = parentMoveId; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getInput() { return input; }
+    public void setInput(String input) { this.input = input; }
+
+    public MoveType getMoveType() { return moveType; }
+    public void setMoveType(MoveType moveType) { this.moveType = moveType; }
+
+    public Integer getSuperArtLevel() { return superArtLevel; }
+    public void setSuperArtLevel(Integer superArtLevel) { this.superArtLevel = superArtLevel; }
+
+    public Integer getDamage() { return damage; }
+    public void setDamage(Integer damage) { this.damage = damage; }
+
+    public Integer getChipDamage() { return chipDamage; }
+    public void setChipDamage(Integer chipDamage) { this.chipDamage = chipDamage; }
+
+    public Integer getStartupFrames() { return startupFrames; }
+    public void setStartupFrames(Integer startupFrames) { this.startupFrames = startupFrames; }
+
+    public Integer getActiveFrames() { return activeFrames; }
+    public void setActiveFrames(Integer activeFrames) { this.activeFrames = activeFrames; }
+
+    public Integer getRecoveryFrames() { return recoveryFrames; }
+    public void setRecoveryFrames(Integer recoveryFrames) { this.recoveryFrames = recoveryFrames; }
+
+    public Integer getOnHitAdvantage() { return onHitAdvantage; }
+    public void setOnHitAdvantage(Integer onHitAdvantage) { this.onHitAdvantage = onHitAdvantage; }
+
+    public Integer getOnBlockAdvantage() { return onBlockAdvantage; }
+    public void setOnBlockAdvantage(Integer onBlockAdvantage) { this.onBlockAdvantage = onBlockAdvantage; }
+
+    public Integer getOnCounterHitAdvantage() { return onCounterHitAdvantage; }
+    public void setOnCounterHitAdvantage(Integer onCounterHitAdvantage) { this.onCounterHitAdvantage = onCounterHitAdvantage; }
+
+    public Integer getOnPunishCounterAdvantage() { return onPunishCounterAdvantage; }
+    public void setOnPunishCounterAdvantage(Integer onPunishCounterAdvantage) { this.onPunishCounterAdvantage = onPunishCounterAdvantage; }
+
+    public Integer getDriveRushOnHit() { return driveRushOnHit; }
+    public void setDriveRushOnHit(Integer driveRushOnHit) { this.driveRushOnHit = driveRushOnHit; }
+
+    public Integer getDriveRushOnBlock() { return driveRushOnBlock; }
+    public void setDriveRushOnBlock(Integer driveRushOnBlock) { this.driveRushOnBlock = driveRushOnBlock; }
+
+    public Boolean getHasArmor() { return hasArmor; }
+    public void setHasArmor(Boolean hasArmor) { this.hasArmor = hasArmor; }
+
+    public Integer getArmorHits() { return armorHits; }
+    public void setArmorHits(Integer armorHits) { this.armorHits = armorHits; }
+
+    public String getCancelOptions() { return cancelOptions; }
+    public void setCancelOptions(String cancelOptions) { this.cancelOptions = cancelOptions; }
+
+    public String getNotes() { return notes; }
+    public void setNotes(String notes) { this.notes = notes; }
+}

--- a/src/main/java/com/fgc/framedata_api/response/ListMoveResponse.java
+++ b/src/main/java/com/fgc/framedata_api/response/ListMoveResponse.java
@@ -1,0 +1,24 @@
+package com.fgc.framedata_api.response;
+
+import com.fgc.framedata_api.dto.MoveDTO;
+
+import java.util.List;
+
+public class ListMoveResponse {
+
+    private List<MoveDTO> moves;
+
+    public ListMoveResponse() {}
+
+    public ListMoveResponse(List<MoveDTO> moves) {
+        this.moves = moves;
+    }
+
+    public List<MoveDTO> getMoves() {
+        return moves;
+    }
+
+    public void setMoves(List<MoveDTO> moves) {
+        this.moves = moves;
+    }
+}

--- a/src/main/java/com/fgc/framedata_api/service/CharacterService.java
+++ b/src/main/java/com/fgc/framedata_api/service/CharacterService.java
@@ -33,6 +33,7 @@ public class CharacterService implements CharacterServiceInterface {
         Character character = new Character();
         character.setGame(game);
         character.setName(createCharacterRequest.getName());
+        character.setPatchVersion(createCharacterRequest.getPatchVersion());
         character = characterRepository.save(character);
         return mapToDTO(character);
     }
@@ -56,6 +57,9 @@ public class CharacterService implements CharacterServiceInterface {
         if (updateCharacterRequest.getName() != null && !updateCharacterRequest.getName().isEmpty()) {
             existingCharacter.setName(updateCharacterRequest.getName());
         }
+        if (updateCharacterRequest.getPatchVersion() != null) {
+            existingCharacter.setPatchVersion(updateCharacterRequest.getPatchVersion());
+        }
         Character updatedCharacter = characterRepository.save(existingCharacter);
         return mapToDTO(updatedCharacter);
     }
@@ -71,6 +75,7 @@ public class CharacterService implements CharacterServiceInterface {
         CharacterDTO dto = new CharacterDTO();
         dto.setId(character.getId());
         dto.setName(character.getName());
+        dto.setPatchVersion(character.getPatchVersion());
         if (character.getGame() != null) {
             dto.setGameName(character.getGame().getName());
         }

--- a/src/main/java/com/fgc/framedata_api/service/MoveService.java
+++ b/src/main/java/com/fgc/framedata_api/service/MoveService.java
@@ -1,0 +1,145 @@
+package com.fgc.framedata_api.service;
+
+import com.fgc.framedata_api.dto.MoveDTO;
+import com.fgc.framedata_api.model.Character;
+import com.fgc.framedata_api.model.Move;
+import com.fgc.framedata_api.repository.CharacterRepository;
+import com.fgc.framedata_api.repository.MoveRepository;
+import com.fgc.framedata_api.request.CreateMoveRequest;
+import com.fgc.framedata_api.request.UpdateMoveRequest;
+import com.fgc.framedata_api.utils.CustomExceptions;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MoveService implements MoveServiceInterface {
+
+    private final MoveRepository moveRepository;
+    private final CharacterRepository characterRepository;
+
+    public MoveService(MoveRepository moveRepository, CharacterRepository characterRepository) {
+        this.moveRepository = moveRepository;
+        this.characterRepository = characterRepository;
+    }
+
+    public MoveDTO addMove(Long characterId, CreateMoveRequest request) {
+        Character character = characterRepository.findById(characterId)
+                .orElseThrow(() -> new CustomExceptions.CharacterNotFoundException("Character not found with id: " + characterId));
+
+        Move move = new Move();
+        move.setCharacter(character);
+        move.setName(request.getName());
+        move.setInput(request.getInput());
+        move.setMoveType(request.getMoveType());
+        move.setSuperArtLevel(request.getSuperArtLevel());
+        move.setDamage(request.getDamage());
+        move.setChipDamage(request.getChipDamage());
+        move.setStartupFrames(request.getStartupFrames());
+        move.setActiveFrames(request.getActiveFrames());
+        move.setRecoveryFrames(request.getRecoveryFrames());
+        move.setOnHitAdvantage(request.getOnHitAdvantage());
+        move.setOnBlockAdvantage(request.getOnBlockAdvantage());
+        move.setOnCounterHitAdvantage(request.getOnCounterHitAdvantage());
+        move.setOnPunishCounterAdvantage(request.getOnPunishCounterAdvantage());
+        move.setDriveRushOnHit(request.getDriveRushOnHit());
+        move.setDriveRushOnBlock(request.getDriveRushOnBlock());
+        move.setHasArmor(request.getHasArmor() != null ? request.getHasArmor() : false);
+        move.setArmorHits(request.getArmorHits());
+        move.setCancelOptions(request.getCancelOptions());
+        move.setNotes(request.getNotes());
+
+        if (request.getParentMoveId() != null) {
+            Move parentMove = moveRepository.findById(request.getParentMoveId())
+                    .orElseThrow(() -> new CustomExceptions.MoveNotFoundException("Parent move not found with id: " + request.getParentMoveId()));
+            move.setParentMove(parentMove);
+        }
+
+        move = moveRepository.save(move);
+        return mapToDTO(move);
+    }
+
+    public List<MoveDTO> getAllMovesByCharacter(Long characterId) {
+        if (!characterRepository.existsById(characterId)) {
+            throw new CustomExceptions.CharacterNotFoundException("Character not found with id: " + characterId);
+        }
+        return moveRepository.findAllByCharacterId(characterId).stream()
+                .map(this::mapToDTO)
+                .toList();
+    }
+
+    public MoveDTO getMoveById(Long id) {
+        Move move = moveRepository.findById(id)
+                .orElseThrow(() -> new CustomExceptions.MoveNotFoundException("Move not found with id: " + id));
+        return mapToDTO(move);
+    }
+
+    public MoveDTO updateMove(Long id, UpdateMoveRequest request) {
+        Move move = moveRepository.findById(id)
+                .orElseThrow(() -> new CustomExceptions.MoveNotFoundException("Move not found with id: " + id));
+
+        if (request.getName() != null) move.setName(request.getName());
+        if (request.getInput() != null) move.setInput(request.getInput());
+        if (request.getMoveType() != null) move.setMoveType(request.getMoveType());
+        if (request.getSuperArtLevel() != null) move.setSuperArtLevel(request.getSuperArtLevel());
+        if (request.getDamage() != null) move.setDamage(request.getDamage());
+        if (request.getChipDamage() != null) move.setChipDamage(request.getChipDamage());
+        if (request.getStartupFrames() != null) move.setStartupFrames(request.getStartupFrames());
+        if (request.getActiveFrames() != null) move.setActiveFrames(request.getActiveFrames());
+        if (request.getRecoveryFrames() != null) move.setRecoveryFrames(request.getRecoveryFrames());
+        if (request.getOnHitAdvantage() != null) move.setOnHitAdvantage(request.getOnHitAdvantage());
+        if (request.getOnBlockAdvantage() != null) move.setOnBlockAdvantage(request.getOnBlockAdvantage());
+        if (request.getOnCounterHitAdvantage() != null) move.setOnCounterHitAdvantage(request.getOnCounterHitAdvantage());
+        if (request.getOnPunishCounterAdvantage() != null) move.setOnPunishCounterAdvantage(request.getOnPunishCounterAdvantage());
+        if (request.getDriveRushOnHit() != null) move.setDriveRushOnHit(request.getDriveRushOnHit());
+        if (request.getDriveRushOnBlock() != null) move.setDriveRushOnBlock(request.getDriveRushOnBlock());
+        if (request.getHasArmor() != null) move.setHasArmor(request.getHasArmor());
+        if (request.getArmorHits() != null) move.setArmorHits(request.getArmorHits());
+        if (request.getCancelOptions() != null) move.setCancelOptions(request.getCancelOptions());
+        if (request.getNotes() != null) move.setNotes(request.getNotes());
+
+        if (request.getParentMoveId() != null) {
+            Move parentMove = moveRepository.findById(request.getParentMoveId())
+                    .orElseThrow(() -> new CustomExceptions.MoveNotFoundException("Parent move not found with id: " + request.getParentMoveId()));
+            move.setParentMove(parentMove);
+        }
+
+        move = moveRepository.save(move);
+        return mapToDTO(move);
+    }
+
+    public void deleteMove(Long id) {
+        Move move = moveRepository.findById(id)
+                .orElseThrow(() -> new CustomExceptions.MoveNotFoundException("Move not found with id: " + id));
+        moveRepository.deleteById(move.getId());
+    }
+
+    private MoveDTO mapToDTO(Move move) {
+        MoveDTO dto = new MoveDTO();
+        dto.setId(move.getId());
+        dto.setCharacterId(move.getCharacter().getId());
+        dto.setName(move.getName());
+        dto.setInput(move.getInput());
+        dto.setMoveType(move.getMoveType());
+        dto.setSuperArtLevel(move.getSuperArtLevel());
+        dto.setDamage(move.getDamage());
+        dto.setChipDamage(move.getChipDamage());
+        dto.setStartupFrames(move.getStartupFrames());
+        dto.setActiveFrames(move.getActiveFrames());
+        dto.setRecoveryFrames(move.getRecoveryFrames());
+        dto.setOnHitAdvantage(move.getOnHitAdvantage());
+        dto.setOnBlockAdvantage(move.getOnBlockAdvantage());
+        dto.setOnCounterHitAdvantage(move.getOnCounterHitAdvantage());
+        dto.setOnPunishCounterAdvantage(move.getOnPunishCounterAdvantage());
+        dto.setDriveRushOnHit(move.getDriveRushOnHit());
+        dto.setDriveRushOnBlock(move.getDriveRushOnBlock());
+        dto.setHasArmor(move.getHasArmor());
+        dto.setArmorHits(move.getArmorHits());
+        dto.setCancelOptions(move.getCancelOptions());
+        dto.setNotes(move.getNotes());
+        if (move.getParentMove() != null) {
+            dto.setParentMoveId(move.getParentMove().getId());
+        }
+        return dto;
+    }
+}

--- a/src/main/java/com/fgc/framedata_api/service/MoveServiceInterface.java
+++ b/src/main/java/com/fgc/framedata_api/service/MoveServiceInterface.java
@@ -1,0 +1,15 @@
+package com.fgc.framedata_api.service;
+
+import com.fgc.framedata_api.dto.MoveDTO;
+import com.fgc.framedata_api.request.CreateMoveRequest;
+import com.fgc.framedata_api.request.UpdateMoveRequest;
+
+import java.util.List;
+
+public interface MoveServiceInterface {
+    MoveDTO addMove(Long characterId, CreateMoveRequest request);
+    List<MoveDTO> getAllMovesByCharacter(Long characterId);
+    MoveDTO getMoveById(Long id);
+    MoveDTO updateMove(Long id, UpdateMoveRequest request);
+    void deleteMove(Long id);
+}

--- a/src/main/java/com/fgc/framedata_api/utils/CustomExceptions.java
+++ b/src/main/java/com/fgc/framedata_api/utils/CustomExceptions.java
@@ -13,4 +13,10 @@ public class CustomExceptions {
             super(message);
         }
     }
+
+    public static class MoveNotFoundException extends RuntimeException {
+        public MoveNotFoundException(String message) {
+            super(message);
+        }
+    }
 }

--- a/src/main/resources/db/migration/V5__add_patch_version_to_characters.sql
+++ b/src/main/resources/db/migration/V5__add_patch_version_to_characters.sql
@@ -1,0 +1,2 @@
+ALTER TABLE characters
+ADD COLUMN patch_version VARCHAR(20);

--- a/src/main/resources/db/migration/V6__recreate_moves_table.sql
+++ b/src/main/resources/db/migration/V6__recreate_moves_table.sql
@@ -1,0 +1,26 @@
+DROP TABLE moves;
+
+CREATE TABLE moves (
+    id                          BIGSERIAL PRIMARY KEY,
+    character_id                BIGINT NOT NULL REFERENCES characters(id),
+    parent_move_id              BIGINT REFERENCES moves(id),
+    name                        VARCHAR(100) NOT NULL,
+    input                       VARCHAR(50) NOT NULL,
+    move_type                   VARCHAR(50) NOT NULL,
+    super_art_level             INTEGER,
+    damage                      INTEGER,
+    chip_damage                 INTEGER,
+    startup_frames              INTEGER,
+    active_frames               INTEGER,
+    recovery_frames             INTEGER,
+    on_hit_advantage            INTEGER,
+    on_block_advantage          INTEGER,
+    on_counter_hit_advantage    INTEGER,
+    on_punish_counter_advantage INTEGER,
+    drive_rush_on_hit           INTEGER,
+    drive_rush_on_block         INTEGER,
+    has_armor                   BOOLEAN NOT NULL DEFAULT FALSE,
+    armor_hits                  INTEGER,
+    cancel_options              VARCHAR(200),
+    notes                       TEXT
+);

--- a/src/test/java/com/fgc/framedata_api/service/integration/MoveControllerIntegrationTest.java
+++ b/src/test/java/com/fgc/framedata_api/service/integration/MoveControllerIntegrationTest.java
@@ -1,0 +1,125 @@
+package com.fgc.framedata_api.service.integration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class MoveControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private Long createGame() throws Exception {
+        String response = mockMvc.perform(post("/games/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Street Fighter 6\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return Long.parseLong(response.split("\"id\":")[1].split(",")[0]);
+    }
+
+    private Long createCharacter(Long gameId) throws Exception {
+        String response = mockMvc.perform(post("/characters/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Ryu\", \"gameId\": " + gameId + ", \"patchVersion\": \"20250222\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return Long.parseLong(response.split("\"id\":")[1].split(",")[0]);
+    }
+
+    @Test
+    void shouldCreateAndGetAllMoves() throws Exception {
+        Long gameId = createGame();
+        Long characterId = createCharacter(gameId);
+
+        mockMvc.perform(post("/characters/" + characterId + "/moves")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Hadoken\", \"input\": \"236P\", \"moveType\": \"SPECIAL\", \"startupFrames\": 13, \"hasArmor\": false}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Hadoken"))
+                .andExpect(jsonPath("$.input").value("236P"))
+                .andExpect(jsonPath("$.moveType").value("SPECIAL"));
+
+        mockMvc.perform(get("/characters/" + characterId + "/moves"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.moves").isArray())
+                .andExpect(jsonPath("$.moves[0].name").value("Hadoken"));
+    }
+
+    @Test
+    void shouldReturnNotFound_whenCharacterDoesNotExist() throws Exception {
+        mockMvc.perform(get("/characters/999/moves"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldGetMoveById() throws Exception {
+        Long gameId = createGame();
+        Long characterId = createCharacter(gameId);
+
+        String response = mockMvc.perform(post("/characters/" + characterId + "/moves")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Shoryuken\", \"input\": \"623P\", \"moveType\": \"SPECIAL\", \"hasArmor\": true, \"armorHits\": 1}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        Long moveId = Long.parseLong(response.split("\"id\":")[1].split(",")[0]);
+
+        mockMvc.perform(get("/characters/" + characterId + "/moves/" + moveId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Shoryuken"))
+                .andExpect(jsonPath("$.hasArmor").value(true));
+    }
+
+    @Test
+    void shouldUpdateMove() throws Exception {
+        Long gameId = createGame();
+        Long characterId = createCharacter(gameId);
+
+        String response = mockMvc.perform(post("/characters/" + characterId + "/moves")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Hadoken\", \"input\": \"236P\", \"moveType\": \"SPECIAL\", \"startupFrames\": 13, \"hasArmor\": false}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        Long moveId = Long.parseLong(response.split("\"id\":")[1].split(",")[0]);
+
+        mockMvc.perform(put("/characters/" + characterId + "/moves/" + moveId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"startupFrames\": 12}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.startupFrames").value(12));
+    }
+
+    @Test
+    void shouldDeleteMove() throws Exception {
+        Long gameId = createGame();
+        Long characterId = createCharacter(gameId);
+
+        String response = mockMvc.perform(post("/characters/" + characterId + "/moves")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Hadoken\", \"input\": \"236P\", \"moveType\": \"SPECIAL\", \"hasArmor\": false}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        Long moveId = Long.parseLong(response.split("\"id\":")[1].split(",")[0]);
+
+        mockMvc.perform(delete("/characters/" + characterId + "/moves/" + moveId))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/characters/" + characterId + "/moves/" + moveId))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/fgc/framedata_api/service/unit/GameServiceTest.java
+++ b/src/test/java/com/fgc/framedata_api/service/unit/GameServiceTest.java
@@ -82,6 +82,7 @@ class GameServiceTest {
         createRequest.setName("Test Game");
 
         Game game = new Game();
+        game.setId(1L);
         game.setName(createRequest.getName());
         game.setCreatedAt(LocalDateTime.now());
         game.setUpdatedAt(LocalDateTime.now());

--- a/src/test/java/com/fgc/framedata_api/service/unit/MoveServiceTest.java
+++ b/src/test/java/com/fgc/framedata_api/service/unit/MoveServiceTest.java
@@ -1,0 +1,201 @@
+package com.fgc.framedata_api.service.unit;
+
+import com.fgc.framedata_api.dto.MoveDTO;
+import com.fgc.framedata_api.model.Character;
+import com.fgc.framedata_api.model.Game;
+import com.fgc.framedata_api.model.Move;
+import com.fgc.framedata_api.model.MoveType;
+import com.fgc.framedata_api.repository.CharacterRepository;
+import com.fgc.framedata_api.repository.MoveRepository;
+import com.fgc.framedata_api.request.CreateMoveRequest;
+import com.fgc.framedata_api.request.UpdateMoveRequest;
+import com.fgc.framedata_api.service.MoveService;
+import com.fgc.framedata_api.utils.CustomExceptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MoveServiceTest {
+
+    @Mock
+    private MoveRepository moveRepository;
+
+    @Mock
+    private CharacterRepository characterRepository;
+
+    @InjectMocks
+    private MoveService moveService;
+
+    private Character buildCharacter() {
+        Game game = new Game();
+        game.setId(1L);
+        game.setName("Street Fighter 6");
+
+        Character character = new Character();
+        character.setId(1L);
+        character.setName("Ryu");
+        character.setGame(game);
+        return character;
+    }
+
+    private Move buildMove(Character character) {
+        Move move = new Move();
+        move.setId(1L);
+        move.setCharacter(character);
+        move.setName("Hadoken");
+        move.setInput("236P");
+        move.setMoveType(MoveType.SPECIAL);
+        move.setStartupFrames(13);
+        move.setHasArmor(false);
+        return move;
+    }
+
+    @Test
+    void addMove_shouldThrow_whenCharacterNotFound() {
+        when(characterRepository.findById(1L)).thenReturn(Optional.empty());
+
+        CreateMoveRequest request = new CreateMoveRequest();
+        request.setName("Hadoken");
+        request.setInput("236P");
+        request.setMoveType(MoveType.SPECIAL);
+
+        try {
+            moveService.addMove(1L, request);
+        } catch (CustomExceptions.CharacterNotFoundException e) {
+            assert e.getMessage().equals("Character not found with id: 1");
+        }
+    }
+
+    @Test
+    void addMove_shouldReturnMoveDTO_whenRequestIsValid() {
+        Character character = buildCharacter();
+        Move move = buildMove(character);
+
+        when(characterRepository.findById(1L)).thenReturn(Optional.of(character));
+        when(moveRepository.save(any(Move.class))).thenReturn(move);
+
+        CreateMoveRequest request = new CreateMoveRequest();
+        request.setName("Hadoken");
+        request.setInput("236P");
+        request.setMoveType(MoveType.SPECIAL);
+
+        MoveDTO result = moveService.addMove(1L, request);
+        assert result != null;
+        assert result.getName().equals("Hadoken");
+        assert result.getMoveType() == MoveType.SPECIAL;
+    }
+
+    @Test
+    void addMove_shouldThrow_whenParentMoveNotFound() {
+        Character character = buildCharacter();
+
+        when(characterRepository.findById(1L)).thenReturn(Optional.of(character));
+        when(moveRepository.findById(99L)).thenReturn(Optional.empty());
+
+        CreateMoveRequest request = new CreateMoveRequest();
+        request.setName("Follow-up");
+        request.setInput("P");
+        request.setMoveType(MoveType.TARGET_COMBO);
+        request.setParentMoveId(99L);
+
+        try {
+            moveService.addMove(1L, request);
+        } catch (CustomExceptions.MoveNotFoundException e) {
+            assert e.getMessage().equals("Parent move not found with id: 99");
+        }
+    }
+
+    @Test
+    void getMoveById_shouldThrow_whenMoveNotFound() {
+        when(moveRepository.findById(1L)).thenReturn(Optional.empty());
+
+        try {
+            moveService.getMoveById(1L);
+        } catch (CustomExceptions.MoveNotFoundException e) {
+            assert e.getMessage().equals("Move not found with id: 1");
+        }
+    }
+
+    @Test
+    void getMoveById_shouldReturnMoveDTO_whenFound() {
+        Character character = buildCharacter();
+        Move move = buildMove(character);
+
+        when(moveRepository.findById(1L)).thenReturn(Optional.of(move));
+
+        MoveDTO result = moveService.getMoveById(1L);
+        assert result != null;
+        assert result.getId().equals(1L);
+        assert result.getName().equals("Hadoken");
+    }
+
+    @Test
+    void updateMove_shouldThrow_whenMoveNotFound() {
+        when(moveRepository.findById(1L)).thenReturn(Optional.empty());
+
+        try {
+            moveService.updateMove(1L, new UpdateMoveRequest());
+        } catch (CustomExceptions.MoveNotFoundException e) {
+            assert e.getMessage().equals("Move not found with id: 1");
+        }
+    }
+
+    @Test
+    void updateMove_shouldReturnUpdatedMoveDTO_whenRequestIsValid() {
+        Character character = buildCharacter();
+        Move move = buildMove(character);
+
+        when(moveRepository.findById(1L)).thenReturn(Optional.of(move));
+        when(moveRepository.save(any(Move.class))).thenReturn(move);
+
+        UpdateMoveRequest request = new UpdateMoveRequest();
+        request.setStartupFrames(14);
+
+        MoveDTO result = moveService.updateMove(1L, request);
+        assert result != null;
+    }
+
+    @Test
+    void getAllMovesByCharacter_shouldThrow_whenCharacterNotFound() {
+        when(characterRepository.existsById(1L)).thenReturn(false);
+
+        try {
+            moveService.getAllMovesByCharacter(1L);
+        } catch (CustomExceptions.CharacterNotFoundException e) {
+            assert e.getMessage().equals("Character not found with id: 1");
+        }
+    }
+
+    @Test
+    void getAllMovesByCharacter_shouldReturnList_whenCharacterExists() {
+        Character character = buildCharacter();
+        Move move = buildMove(character);
+
+        when(characterRepository.existsById(1L)).thenReturn(true);
+        when(moveRepository.findAllByCharacterId(1L)).thenReturn(List.of(move));
+
+        List<MoveDTO> result = moveService.getAllMovesByCharacter(1L);
+        assert result.size() == 1;
+        assert result.get(0).getName().equals("Hadoken");
+    }
+
+    @Test
+    void deleteMove_shouldThrow_whenMoveNotFound() {
+        when(moveRepository.findById(1L)).thenReturn(Optional.empty());
+
+        try {
+            moveService.deleteMove(1L);
+        } catch (CustomExceptions.MoveNotFoundException e) {
+            assert e.getMessage().equals("Move not found with id: 1");
+        }
+    }
+}


### PR DESCRIPTION
- Add Move entity with all SF6-specific fields (startup/active/recovery, on-hit/block/counter-hit/punish-counter advantage, Drive Rush advantage, armor, cancel options) and self-referential parent_move_id for follow-ups, target combos, and stance moves
- Add MoveType enum: NORMAL, SPECIAL, OD_SPECIAL, SUPER_ART, THROW, STANCE, TARGET_COMBO
- Add MoveRepository with findAllByCharacterId and findAllByParentMoveId
- Add patch_version to Character entity, DTO, and request models
- Add MoveService, MoveServiceInterface, MoveController under /characters/{id}/moves
- Add MoveNotFoundException to CustomExceptions
- Add Flyway migrations V5 (patch_version column) and V6 (recreate moves table)
- Add unit tests (MoveServiceTest) and integration tests (MoveControllerIntegrationTest)
- Fix pre-existing GameServiceTest stub mismatch (game id was null)